### PR TITLE
🔥 Hotfix: Fix epic description edit button not working

### DIFF
--- a/src/components/data-display/MarkdownViewer.vue
+++ b/src/components/data-display/MarkdownViewer.vue
@@ -18,7 +18,7 @@
     <!-- Markdown content (Requirements 3.1-3.9) -->
     <div v-else class="markdown-content" :style="{ maxHeight }">
       <MdPreview :model-value="internalValue" :language="language" :theme="editorTheme" :preview-theme="previewTheme"
-        :code-theme="codeTheme" :editor-id="`markdown-viewer-${Math.random()}`" class="markdown-viewer"
+        :code-theme="codeTheme" :editor-id="`markdown-viewer-${Math.random().toString().replace('.', '')}`" class="markdown-viewer"
         @on-error="handleRenderError" />
     </div>
   </div>


### PR DESCRIPTION
## Problem
The edit description button on epic detail pages was not working - clicking it did nothing and JavaScript errors were appearing in the console.

## Root Cause
The issue was in the `MarkdownViewer.vue` component where `Math.random()` was used to generate unique IDs for the markdown editor:

```vue
:editor-id="`markdown-viewer-${Math.random()}`"
```

This generated IDs like `markdown-viewer-0.8837210853639411` with dots, which created invalid CSS selectors. When the component tried to use `querySelectorAll` with these selectors, it threw `SyntaxError` exceptions that prevented the fullscreen editor from opening.

## Solution
Fixed the ID generation to remove dots from the random number:

```vue
:editor-id="`markdown-viewer-${Math.random().toString().replace('.', '')}`"
```

Now IDs are generated as `markdown-viewer-08837210853639411` (without dots), creating valid CSS selectors.

## Testing
✅ Tested in browser - edit description button now works correctly
✅ Fullscreen markdown editor opens and closes properly  
✅ No more JavaScript errors in console
✅ Epic description editing functionality fully restored

## Impact
- **Users**: Can now successfully edit epic descriptions using the fullscreen editor
- **Developers**: No more console errors when viewing epic detail pages
- **System**: Improved stability and user experience

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Changes have been tested in browser
- [x] No new console errors introduced
- [x] Functionality works as expected